### PR TITLE
Fix node-gyp linking to wrong c++ std lib on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,11 +3,12 @@
         "target_name": "native",
         "sources": [ "src/set.cpp", "src/iterator.cpp" ],
         "include_dirs" : [ "<!(node -e \"require('nan')\")" ],
+        "cflags": ["-std=c++11", "-Wall"],
         "conditions": [
-            ['OS=="linux"', {
-                "cflags": [ "-std=c++11", "-Wall" ]
-            }, {
-                "cflags": [ "-std=c++11", "-stdlib=libc++", "-Wall" ]
+            ['OS == "mac"', {
+                'xcode_settings': {
+                    'CLANG_CXX_LIBRARY': 'libc++'
+                }
             }]
         ]
     }]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-native-set",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Native es6 set for Node",
   "main": "./index.js",
   "keywords": [

--- a/src/set.h
+++ b/src/set.h
@@ -3,13 +3,8 @@
 
 #include <string>
 #include <iostream>
-#ifdef __APPLE__
-#include <tr1/unordered_set>
-#define unordered_set std::tr1::unordered_set
-#else
 #include <unordered_set>
 #define unordered_set std::unordered_set
-#endif
 #include <node.h>
 #include <nan.h>
 #include "v8_value_hasher.h"

--- a/src/v8_value_hasher.h
+++ b/src/v8_value_hasher.h
@@ -4,13 +4,8 @@
 #include <string>
 #include <iostream>
 #include <node.h>
-#ifdef __APPLE__
-#include <tr1/unordered_set>
-#define hash std::tr1::hash
-#else
 #include <unordered_set>
 #define hash std::hash
-#endif
 #include <nan.h>
 
 class VersionedPersistent {


### PR DESCRIPTION
* add .gitignore
* bump version patch